### PR TITLE
specify destination client type as V1

### DIFF
--- a/scripts/open-tunnel.sh
+++ b/scripts/open-tunnel.sh
@@ -14,6 +14,6 @@ if [ -e  ]
 
 aws iotsecuretunneling open-tunnel --destination-config thingName=$thingName,services=SSH --timeout-config maxLifetimeTimeoutMinutes=$timeOut | echo $message | destinationToken=$(jq '.destinationAccessToken')
 echo connecting with destination token $destinationToken
-nohup ./localproxy -r $REGION -s 18022 -t $destinationToken &>tunnel.log
+nohup ./localproxy -r $REGION -s 18022 -t $destinationToken --destination-client-type V1 &>tunnel.log
 sleep 120
 ssh pi@localhost -p 18022

--- a/tunnel.ts
+++ b/tunnel.ts
@@ -56,6 +56,8 @@ class Tunnel {
           this._services.map((s) => s + "=" + TunnelServices[s]).join(","),
           "-t",
           this._token,
+          "--destination-client-type",
+          "V1"
         ]);
         localProxyProcess.on("error", (e: Error) => {
           error("error from localproxy execution", e);


### PR DESCRIPTION
----
The AWS console uses a localproxy version that is incompatible to the latest destination client type. Specified it as V1 in order to still be able to use the console.

see https://github.com/aws-samples/aws-iot-securetunneling-localproxy/issues/152